### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ must be available as a local JAR.
 ``` shell
 cd metabase
 lein install
+mkdir plugins
 cd ../metabase-datomic
 lein with-profiles +datomic-free uberjar
 # lein with-profiles +datomic-pro uberjar

--- a/README.md
+++ b/README.md
@@ -70,12 +70,15 @@ user=> (setup!)
 
 ## Installing
 
-The general process is to build an uberjar, and copy the result into your
-Metabase `plugins/` directory. You can build a jar based on datomic-free, or
-datomic-pro (assuming you have a license).
+The general process is to build an uberjar, and copy the result into
+your Metabase `plugins/` directory. You can build a jar based on
+datomic-free, or datomic-pro (assuming you have a license). Metabase
+must be available as a local JAR.
 
 ``` shell
-cd metabase-datomic
+cd metabase
+lein install
+cd ../metabase-datomic
 lein with-profiles +datomic-free uberjar
 # lein with-profiles +datomic-pro uberjar
 cp target/uberjar/datomic.metabase-driver.jar ../metabase/plugins


### PR DESCRIPTION
 - `lein ... uberjar` fails if Metabase is not available. Installing Metabase locally allows lein to build the metabase-datomic JAR.
 - `lein run -m metabase.core` fails if `plugins` is not `mkdir`'d prior to `cp`ing the uberjar